### PR TITLE
Fix newly added chips sometimes cover newest chat bubbles

### DIFF
--- a/js/bots.js
+++ b/js/bots.js
@@ -19,7 +19,7 @@ function loadBot(name, map) {
   req = $.ajax("bots/" + name + ".js", {
     async: false,
     dataType: "script",
-  });  
+  });
   req.done(function(data) {
     console.log("Bot '" + name + "' loaded successfully");
     map[name] = eval(data);
@@ -36,14 +36,11 @@ var bots = [
   "besties",
   "emotionFlow",
   "kittens",
-  "kittens1",
   "maraudersMap",
   "petSim",
   "quiz",
-  "quiz_m0",
   "rhymes",
   "tesla",
-  "testIf",
 ];
 
 for (var i = 0; i < bots.length; i++) {

--- a/js/bots.js
+++ b/js/bots.js
@@ -19,7 +19,7 @@ function loadBot(name, map) {
   req = $.ajax("bots/" + name + ".js", {
     async: false,
     dataType: "script",
-  });
+  });  
   req.done(function(data) {
     console.log("Bot '" + name + "' loaded successfully");
     map[name] = eval(data);

--- a/js/bots.js
+++ b/js/bots.js
@@ -19,7 +19,7 @@ function loadBot(name, map) {
   req = $.ajax("bots/" + name + ".js", {
     async: false,
     dataType: "script",
-  });
+  }); 
   req.done(function(data) {
     console.log("Bot '" + name + "' loaded successfully");
     map[name] = eval(data);

--- a/js/chat.js
+++ b/js/chat.js
@@ -82,6 +82,7 @@ var chat = {
       });
 
     });
+    chat.bubbleHolder.scrollTop(chat.bubbleHolder[0].scrollHeight);
   },
 
   clearChips: function() {


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - In some cases (specifically the `kittens.js` sample code in [README.md](https://github.com/google/bottery/blob/master/README.md)), the resizing of the chat window caused by newly added suggestion chips knocks the scroll position off from the bottom of the chat log, causing the newest message to be obscured.
 - This PR resets the scroll position of the chat window after the chips have been added to prevent this

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  1. Add this simple bot adapted from the `kittens.js` example.
```javascript
bot = {
    states: {
      origin: {
        onEnter: "'You have a kitten!' desired_pets=randomInt(1,5)",
        exits: "->name",
      },
      name: {
        onEnter: "'What do you want to name your kitten?'",
        chips: ["Sarah", "Sarah", "Sarah", "Sarah", "Sarah", ],
        exits: "'*' ->respond_to_name name=INPUT",
      },
      respond_to_name: {
        onEnterSay: "The kitten purrs happily, I guess it likes the name #/name#!",
        exits: "->name"
      },
    },
    initialBlackboard: {
      name: "the kitten",
    },
  }
```
 2. Start the bot, and keep naming the kitten until the chat window begins to scroll.
 3. Without touching the scrollbars, this is what you should see (Windows 10, Chrome 62):

| Before PR (name prompt bubble obscured)  | After PR (name prompt bubble visible) |
| ------------- | ------------- |
| ![chat_panel](https://user-images.githubusercontent.com/5957867/32293456-8bd25f8a-bf19-11e7-9d09-021a0fd35e14.png)  | ![chat_panel_fixed](https://user-images.githubusercontent.com/5957867/32293468-98778d3c-bf19-11e7-8904-19ff2bef9a60.png)  |

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
