### PR TITLE
Removed inactive scrollbars

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -24,7 +24,8 @@
 }
 
 .chat-bubbles {
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: auto;
   flex: 1;
   background-color: hsla(320, 50%, 100%, 1);
 }

--- a/css/page.css
+++ b/css/page.css
@@ -51,7 +51,7 @@ color: rgba(0, 0, 0, .3);
   flex: 1;
   position: relative;
   z-index: 30;
-  overflow: scroll;
+  overflow: auto;
   height: 250px;
   background-color: hsl(20, 10%, 80%);
   
@@ -251,7 +251,7 @@ display: flex;
   flex: 1;
   z-index: 40;
   background-color:  hsla(20, 50%, 85%, .5);
-  overflow: scroll
+  overflow: auto; 
 }
 
 .blackboard-content.blackboard-content-value {

--- a/css/viz.css
+++ b/css/viz.css
@@ -347,7 +347,7 @@ background-color: hsla(290, 80%, 57%, .2);
   flex: 1;
   height: 240px;
   display: flex;
-  overflow: scroll;
+  overflow: auto;
   flex-direction: column;
 }
 


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Currently, many parts of the interface include unused scrollbars on Windows due to the CSS rule `overflow: scroll;`. 
  - By replacing most of them with `overflow: auto;`, a lot of space (and visual clarity) is regained.
  - Examples:

| `overflow: scroll;`  | `overflow: auto;` |
| ------------- | ------------- |
| ![scroll_chat](https://user-images.githubusercontent.com/5957867/32297931-350df3e0-bf27-11e7-84ac-f0680498de45.png)  | ![scroll_chat_fixed](https://user-images.githubusercontent.com/5957867/32298227-182447b0-bf28-11e7-99c2-4ab2591bfa01.png)  |
| ![scroll_state](https://user-images.githubusercontent.com/5957867/32297935-3667bba4-bf27-11e7-8cd8-670812c18ccf.png)  | ![scroll_state_fixed](https://user-images.githubusercontent.com/5957867/32298248-2a191fae-bf28-11e7-98e9-67dd6385da39.png)  |

  - Note: I set the `overflow-y` to `scroll` for `.chat-bubbles` so that the width remains consistent when the vertical scrollbar activates. I think this makes sense for an element whose (net) height is expected to grow over time.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Open Bottery on a Windows PC and notice the reduced number of inactive scrollbars.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - This was tested on the latest versions of Chrome, Firefox, and Edge on Windows 10.
  - I don't have access to a macOS or Linux machine, so these changes should probably be tested on them before merging.
