### PR TITLE
Bot load logging

### DIFF
--- a/js/bots.js
+++ b/js/bots.js
@@ -24,13 +24,13 @@ function loadBot(name, map) {
     console.info("Bot '%s' loaded successfully", name);
     map[name] = eval(data);
   });
-  req.fail(function(jqXHR, exception) {
+  req.fail(function(jqXHR,  textStatus, errorThrown) {
     if (jqXHR.status !== 200) {
     console.error("Bot '%s' could not be loaded: %d (%s)", name, jqXHR.status, jqXHR.statusText);
-    } else if (exception === 'parsererror') {
-      console.error("Bot '%s' could not be parsed. Check for syntax errors.", name);
+    } else if (textStatus === 'parsererror') {
+      console.error("Bot '%s' could not be parsed: %s", name, errorThrown);
     } else {
-      console.error("Bot '%s' could not be loaded: %s", exception);
+      console.error("Bot '%s' could not be loaded: %s", name, errorThrown);
     }
   });
 }

--- a/js/bots.js
+++ b/js/bots.js
@@ -24,8 +24,14 @@ function loadBot(name, map) {
     console.info("Bot '%s' loaded successfully", name);
     map[name] = eval(data);
   });
-  req.fail(function(jqXHR) {
+  req.fail(function(jqXHR, exception) {
+    if (jqXHR.status !== 200) {
     console.error("Bot '%s' could not be loaded: %d (%s)", name, jqXHR.status, jqXHR.statusText);
+    } else if (exception === 'parsererror') {
+      console.error("Bot '%s' could not be parsed. Check for syntax errors.", name);
+    } else {
+      console.error("Bot '%s' could not be loaded: %s", exception);
+    }
   });
 }
 

--- a/js/bots.js
+++ b/js/bots.js
@@ -15,17 +15,17 @@
 // Load bots for demo
 
 function loadBot(name, map) {
-  console.log("loading " + name);
+  console.info("Loading bot '%s'", name);
   req = $.ajax("bots/" + name + ".js", {
     async: false,
     dataType: "script",
   });  
   req.done(function(data) {
-    console.log("Bot '" + name + "' loaded successfully");
+    console.info("Bot '%s' loaded successfully", name);
     map[name] = eval(data);
   });
-  req.fail(function( jqXHR, textStatus ) {
-    console.log("Bot '" + name + "' could not be loaded: " + textStatus );
+  req.fail(function(jqXHR) {
+    console.error("Bot '%s' could not be loaded: %d (%s)", name, jqXHR.status, jqXHR.statusText);
   });
 }
 

--- a/js/bots.js
+++ b/js/bots.js
@@ -26,7 +26,7 @@ function loadBot(name, map) {
   });
   req.fail(function(jqXHR,  textStatus, errorThrown) {
     if (jqXHR.status !== 200) {
-    console.error("Bot '%s' could not be loaded: %d (%s)", name, jqXHR.status, jqXHR.statusText);
+      console.error("Bot '%s' could not be loaded: %d (%s)", name, jqXHR.status, jqXHR.statusText);
     } else if (textStatus === 'parsererror') {
       console.error("Bot '%s' could not be parsed: %s", name, errorThrown);
     } else {


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
 This PR seeks to improve the logs created while loading bots from `bots.js` in the following ways:
  - **Improve consistency**: bot names are always surrounded by single quotes.
  - **Semantic logging**: use distinct `console.info()` and `console.error()` rather than the generic `console.log()` for everything.
  - **String substitution**: neater than joining a bunch of strings together one-by-one.
  - **More useful error messages**: return specific error messages for network errors and parser errors.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  1. Make a bot named `rhymesBad.js` with a syntax error in it.
  2. Add `"rhymesBad"` and `"failOnMe"` (no corresponding `.js` file) to the bots list in `bots.js`.
  3. Start Bottery and check the console:

  | Before PR | After PR |
  |------------|-----------|
  | ![bot_load_logging](https://user-images.githubusercontent.com/5957867/32339636-c457d712-bfce-11e7-8405-785ffe327fce.PNG) | ![bot_load_logging_fixed](https://user-images.githubusercontent.com/5957867/32339643-c9118816-bfce-11e7-8521-0c71cc9b8d28.PNG) |



###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - I haven't been able to prove that the final `console.error()` will actually be executed on a generic exception that occurs within `req.done()`. I don't understand how an error from `eval()` will get passed to `req.fail()`, but adding testing code that produces a different error *won't* and will throw the exception in `req.done()`. I don't have much experience working with [`jQuery.ajax()`](https://api.jquery.com/jquery.ajax/) in the way it's used here, so any advice would be appreciated.
  - Weirdly, it seems that Firefox (57) still tries to parse the non-existent `failOnMe.js` bot after the fact, based on this log message:
![bot_load_logging_ff](https://user-images.githubusercontent.com/5957867/32340290-86df1d30-bfd0-11e7-9461-b247fba3e6ac.PNG)
Adding HTTP exception handling in `req.done()` didn't change this behavior. Doesn't seem to have any negative side effects though ¯\\\_(ツ)\_/¯