### PR TITLE
Improve app startup flow

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -58,12 +58,6 @@ var app = {
       }
     }
 
-    if (!raw) {
-      console.log(inQuotes(id) + " not found");
-      id = defaultMapID;
-      raw = testMaps[id];
-    }
-
     $("#map-select").val(id);
 
     if (raw) {
@@ -179,9 +173,12 @@ $(document).ready(function() {
     setTimeout(update, Math.pow(1 - app.updateSpeed, 2) * 450 + 100);
   }
 
-  var last = localStorage.getItem("lastMap");
+  var startUpMapId = localStorage.getItem("lastMap");
+  if (startUpMapId === null) {
+    startUpMapId = defaultMapID; 
+  }
 
-  app.loadMapByID(last, true);
+  app.loadMapByID(startUpMapId, true);
   update();
 });
 

--- a/js/app.js
+++ b/js/app.js
@@ -61,12 +61,10 @@ var app = {
     $("#map-select").val(id);
 
     if (raw) {
-
       app.loadMap(raw, id);
       localStorage.setItem("lastMap", id);
     } else {
       console.error("Map '%s' not found", id);
-      app.loadMap(testMaps[id], id);
     }
   },
 

--- a/js/app.js
+++ b/js/app.js
@@ -46,7 +46,7 @@ var app = {
 
 
   loadMapByID: function(id, edited) {
-    console.log("Load map by id: " + id + " edited: " + edited);
+    console.info("Load map by id: '%s', edited: %s", id, edited);
     var raw = testMaps[id];
 
     if (edited) {
@@ -54,7 +54,7 @@ var app = {
 
       if (found !== null) {
         raw = JSON.parse(found);
-        console.log("successfully loaded edited" + id);
+        console.info("Successfully loaded edited '%s'", id);
       }
     }
 
@@ -71,7 +71,7 @@ var app = {
       app.loadMap(raw, id);
       localStorage.setItem("lastMap", id);
     } else {
-      console.log("Map" + inQuotes(id) + " not found");
+      console.error("Map '%s' not found", id);
       app.loadMap(testMaps[id], id);
     }
   },

--- a/js/app.js
+++ b/js/app.js
@@ -69,7 +69,7 @@ var app = {
   },
 
   loadMap: function(raw, id) {
-   console.log("LOAD " + id)
+   console.info("Starting '%s'", id)
     if (!raw.settings)
       raw.settings = {
         id: id

--- a/js/editor.js
+++ b/js/editor.js
@@ -118,7 +118,6 @@ function createEditorUI() {
 
   controls.createDropdownControl("savedMap", savedNames, function(val) {
     // load from storage
-    console.log("val:", val);
     app.loadMapByID(val, true);
     //  app.loadMap(JSON.parse(localStorage.getItem(val)), val.substring(4));
   }, editBar)

--- a/js/editor.js
+++ b/js/editor.js
@@ -105,13 +105,16 @@ function createEditorUI() {
 
   // All savednames are prefixed with map_
   var savedNames = [];
-  for (var i = 0, len = localStorage.length; i < len; ++i) {
+  for (var i = 0; i < localStorage.length; ++i) {
     var key = localStorage.key(i);
     if (key.startsWith("map_"))
       savedNames.push(key.substring(4));
   }
 
-  console.log("Saved found: " + savedNames);
+  if (savedNames.length) {
+    const savedNamesString = savedNames.map(mapName => "'"+mapName+"'").join(', ')
+    console.info("Previously saved bots found: " + savedNamesString);
+  }
 
   controls.createDropdownControl("savedMap", savedNames, function(val) {
     // load from storage


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
When Bottery is started up for the first time with a fresh Local Storage, I noticed that there were a lot of unintuitive logs being sent to the console. I dug into `app.js` to figure out what the control flow was that caused these messages to see if I could improve the situation.

Changes include:
  - The logic that would load `defaultMapId` if the requested map ID can't not be found has been moved out of the `loadMapByID()` function and brought it up to the level of the `document.ready()` call that sets up the whole app, where I believe it belongs. This separation of concerns allows `loadMapByID()` to be simplified and removes an unnecessary log message about loading `'null'`.
  - If the requested map ID can't be loaded, `loadMapByID()` will simply log an error message and return, whereas before it would attempt to load the map again for some reason.
  - Light editing of the log messages themselves.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Starting Bottery from scratch:

| Before PR | After PR |
|------------|----------|
| ![log](https://user-images.githubusercontent.com/5957867/32449209-f938d928-c2de-11e7-9191-2690ce830125.PNG) | ![log_fixed](https://user-images.githubusercontent.com/5957867/32449215-fda4b658-c2de-11e7-8405-25012d4a6db2.PNG) |

  - Starting Bottery with edited bots

| Before PR | After PR |
|------------|----------|
| ![log_saved](https://user-images.githubusercontent.com/5957867/32449333-4426107c-c2df-11e7-8233-7b9c19bb498b.PNG) | ![log_saved_fixed](https://user-images.githubusercontent.com/5957867/32449340-47a1feb4-c2df-11e7-903a-918d89e4ff9d.PNG) |

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
Working my way through the logic brought up some concerning issues that will need to be addressed in future changes:
  - Clarification on the "bot"/"map" distinction in function names.
  - Consistent distinct nomenclature for describing the loading of bots into the `testMaps` object, and starting up a bot in the interface. Currently they both use "load" as the verb, which makes it tricky to read what the code is doing by skimming.
  - Addition of [JSDoc](http://usejsdoc.org/about-getting-started.html) comments for every function definition, and overall more comment documentation in the code.
