### PR TITLE
Don't warn when using `--` to decrement

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -335,7 +335,7 @@ function parseMapAction(raw) {
         parsed.expression = parseMapExpression(sections[2]);
       } else {
 
-        if (!(parsed.operator === "++" || parsed.operator === "++")) {
+        if (!(parsed.operator === "++" || parsed.operator === "--")) {
           console.warn(inQuotes(raw) + " is missing a right-hand expression for this assignment operation");
         }
       }


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
When `map.js` parses a map, it warns about missing a right-hand side expression when using the decrement operator (`--`) but not the increment operator (`++`).

I believe this to be a typo on this line: https://github.com/google/bottery/blob/c030aca591066e0b7ee9df560ffac0f7c14be2d7/js/map.js#L338
where the second `++` should be a `--`. That is what I've done in this PR.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  1. Add this minimal bot:
```javascript
bot = {
    states: {
        origin: {
            onEnter: "var1++ var2--"
        }
    },
    initialBlackboard: {
        var1: 5,
        var2: 5
    }
}
```
2. Run it in Bottery after applying this PR. You should no longer see this warning:
```
"var2--" is missing a right-hand expression for this assignment operation
```