### PR TITLE
Improve chat input layout

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -84,13 +84,20 @@
   border-bottom-left-radius:0px;
 }
 
-.chat-inputfield {
-  padding: 5px;
-  
-}
 .chat-inputrow {
-  
-
   padding: 5px;
   background-color: hsla(240, 50%, 80%, 1);
+}
+
+.chat-inputholder {
+  display: flex;
+}
+
+.chat-inputfield {
+  flex-grow: 1;
+  padding: 5px;
+}
+
+.chat-inputbutton {
+  flex-grow: 0;
 }

--- a/js/chat.js
+++ b/js/chat.js
@@ -35,22 +35,22 @@ var chat = {
       class: "chat-bubbles"
     }).appendTo(chat.chatHolder);
 
-    // Create the chat
+    // Create the suggestion chips row
     chat.chipRow = $("<div/>", {
       class: "chat-inputrow chat-chiprow"
     }).appendTo(chat.chatHolder);
 
-    // Create the chat
+    // Create the chat input row
     chat.inputRow = $("<div/>", {
       class: "chat-inputrow"
-
     }).appendTo(chat.chatHolder);
 
-    // text field
+    // Create container for text input and submission button
     var inputHolder = $("<div/>", {
       class: "chat-inputholder"
     }).appendTo(chat.inputRow);
 
+    // Create text field
     chat.inputField = $("<input/>", {
       class: "chat-inputfield"
     }).appendTo(inputHolder).keyup(function(e) {

--- a/js/chat.js
+++ b/js/chat.js
@@ -53,7 +53,6 @@ var chat = {
 
     chat.inputField = $("<input/>", {
       class: "chat-inputfield"
-
     }).appendTo(inputHolder).keyup(function(e) {
       if (e.keyCode === 13) {
         chat.say(1, $(this).val());

--- a/js/chat.js
+++ b/js/chat.js
@@ -38,13 +38,11 @@ var chat = {
     // Create the chat
     chat.dataRow = $("<div/>", {
       class: "chat-datarow"
-
     }).appendTo(chat.chatHolder);
 
     // Create the chat
     chat.chipRow = $("<div/>", {
       class: "chat-inputrow"
-
     }).appendTo(chat.chatHolder);
 
     // Create the chat

--- a/js/chat.js
+++ b/js/chat.js
@@ -52,7 +52,8 @@ var chat = {
 
     // Create text field
     chat.inputField = $("<input/>", {
-      class: "chat-inputfield"
+      class: "chat-inputfield",
+      placeholder: "Message"
     }).appendTo(inputHolder).keyup(function(e) {
       if (e.keyCode === 13) {
         chat.say(1, $(this).val());

--- a/js/chat.js
+++ b/js/chat.js
@@ -36,11 +36,6 @@ var chat = {
     }).appendTo(chat.chatHolder);
 
     // Create the chat
-    chat.dataRow = $("<div/>", {
-      class: "chat-datarow"
-    }).appendTo(chat.chatHolder);
-
-    // Create the chat
     chat.chipRow = $("<div/>", {
       class: "chat-inputrow"
     }).appendTo(chat.chatHolder);

--- a/js/chat.js
+++ b/js/chat.js
@@ -59,6 +59,16 @@ var chat = {
         $(this).val("");
       }
     });
+
+    // Submission button
+    chat.sayButton = $('<input/>', {
+      class: "chat-inputbutton",
+      type: "button",
+      value: "Say",
+    }).appendTo(inputHolder).click(function(e) {
+      chat.say(1, chat.inputField.val());
+      chat.inputField.val("");
+    });
   },
 
   setChips: function(chips) {

--- a/js/chat.js
+++ b/js/chat.js
@@ -37,7 +37,7 @@ var chat = {
 
     // Create the chat
     chat.chipRow = $("<div/>", {
-      class: "chat-inputrow"
+      class: "chat-inputrow chat-chiprow"
     }).appendTo(chat.chatHolder);
 
     // Create the chat


### PR DESCRIPTION
###### Explanation About What Code Achieves:
Currently, the chat text input field is a nondescript white rectangle with an odd width and no affordances for what it is to be used for. This PR makes the following changes:
- Adds placeholder text to the input field to indicate that it can be typed in.
- Adds a "Say" button to submit the text (the original return-to-submit functionality is still there).
- Uses flexbox layout to make the text field fill the available space.
- Removes an unused container element.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
| Before PR | After PR |
|------------|----------|
| ![chat](https://user-images.githubusercontent.com/5957867/32857145-e7db38e6-ca14-11e7-97cc-4ce64910546b.png) | ![chat_fixed](https://user-images.githubusercontent.com/5957867/32857149-eda2b98e-ca14-11e7-95e2-25c31b7b9030.png) |



###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
The resulting HTML structure of the chat input interface could use some semantic enhancements to be more usable for screen readers.
