### PR TITLE
Show 'tesla' map in Controls on first startup

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -164,7 +164,14 @@ $(document).ready(function() {
   chat.init();
   viz.init();
 
-  controls.init();
+  // Get the startUpMapId before we load the controls so we can assign the 
+  // dropdown properly
+  var startUpMapId = localStorage.getItem("lastMap");
+  if (startUpMapId === null) {
+    startUpMapId = defaultMapID; 
+  }
+
+  controls.init(startUpMapId);
 
   function update() {
     if (!app.paused && !app.ioLocked) {
@@ -173,10 +180,7 @@ $(document).ready(function() {
     setTimeout(update, Math.pow(1 - app.updateSpeed, 2) * 450 + 100);
   }
 
-  var startUpMapId = localStorage.getItem("lastMap");
-  if (startUpMapId === null) {
-    startUpMapId = defaultMapID; 
-  }
+
 
   app.loadMapByID(startUpMapId, true);
   update();

--- a/js/controls.js
+++ b/js/controls.js
@@ -23,7 +23,7 @@ function clearDataWithPrefix(prefix) {
 
 
 var controls = {
-  init: function() {
+  init: function(defaultMap) {
     //console.log("Init controls");
     createEditorUI();
 
@@ -39,7 +39,7 @@ var controls = {
     this.createDropdownControl("mapName", Object.keys(testMaps), function(mapName) {
       console.log("load map " + mapName);
       app.loadMapByID(mapName, false);
-    });
+    }, this.holder, Object.keys(testMaps).indexOf(defaultMap));
 
     var div = $("<div/>").appendTo(this.holder);
     this.createSliderControl("updateSpeed", 0, 1, .05, div);
@@ -185,7 +185,7 @@ var controls = {
   },
 
 
-  createDropdownControl: function(key, options, onChange, holder) {
+  createDropdownControl: function(key, options, onChange, holder, defaultOptionIndex) {
     // Check for value
 
     if (holder === undefined)
@@ -204,7 +204,7 @@ var controls = {
         onChange(val);
     })
 
-    var val = controls.getDefaultValue(key, options[0]);
+    var val = controls.getDefaultValue(key, options[defaultOptionIndex]);
     app[key] = val;
     select.val(val);
   },


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
When launching Bottery with a fresh local storage, it will load the "tesla" bot by default. However this information is not communicated to the function that creates the Controls panel, which by default selects the first option in the mapSelect list, which is "amIPsychic". This leads to an inconsistency with which bot is running and which appears in the the Controls selector.

This PR bridges this communications gap by passing the bot-to-be-loaded to the Controls `init()` method, allowing it to select the correct one by default.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
1. Launch Bottery with a fresh local storage
2. See that the bot selection dropdown shows "amIPsychic" but the bot "tesla" is running
3. Apply PR
4. Launch Bottery with a fresh local storage
5. See that the bot selection dropdown now correctly shows "tesla"