### PR TITLE
Replaced resources loaded from RawGit with jsDelivr

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/2.7.0/cytoscape.js"></script>
   <script src="http://marvl.infotech.monash.edu/webcola/cola.v3.min.js"></script>
-  <script src="https://cdn.rawgit.com/cytoscape/cytoscape.js-cola/1.1.1/cytoscape-cola.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/cytoscape/cytoscape.js-cola@1.1.1/cytoscape-cola.js"></script>
 
-  <script src="https://cdn.rawgit.com/galaxykate/tracery-sugar/00e7fc45/js/tracery/tracery.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/galaxykate/tracery-sugar@00e7fc454a54ee270bb1809f354efee925dc6a66/js/tracery/tracery.js"></script>
   
   <script src="js/bots.js"></script>
 


### PR DESCRIPTION
###### Explanation About What Code Achieves:
RawGit announced ([archive.org link](https://web.archive.org/web/20181012200029/https://rawgit.com/)) on October 8th 2018 that they would be shutting down in October 2019, and recommends that users migrate to other services "as soon as you can".

jsDelivr is one of the services recommended in the announcement post, so I used their [RawGit URL conversion tool](https://www.jsdelivr.com/rawgit) to replace the two resources that were being served from RawGit with their equivalents on jsDelivr.

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Run Bottery.
  - Verify that it works as expected.
  - Verify that no network requests are made to `cdn.rawgit.com`.

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
